### PR TITLE
Implement automatic face classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ environment variables with sensible defaults:
 - `SAVE_CHUNK_SIZE`: how often to save progress (default: 10)
 - `SECRET_KEY`: Flask secret key
 - `FLASK_DEBUG`: run the web UI in debug mode
+- `AUTO_CLASSIFY_THRESHOLD`: distance threshold for automatic face naming (default: 0.3)
 
 ## Database
 

--- a/config.py
+++ b/config.py
@@ -21,3 +21,4 @@ class Config:
     DBSCAN_EPS: float = float(os.environ.get("DBSCAN_EPS", "0.4"))
     DBSCAN_MIN_SAMPLES: int = int(os.environ.get("DBSCAN_MIN_SAMPLES", "5"))
     FACE_DETECTION_MODEL: str = os.environ.get("FACE_DETECTION_MODEL", "hog")
+    AUTO_CLASSIFY_THRESHOLD: float = float(os.environ.get("AUTO_CLASSIFY_THRESHOLD", "0.3"))


### PR DESCRIPTION
## Summary
- add configurable `AUTO_CLASSIFY_THRESHOLD`
- implement `classify_new_faces` for automatic naming
- run classification before clustering
- document new config option
- test automatic face classification

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea067907c8332b73e6e160684b72d