### PR TITLE
Add type hints and docstrings

### DIFF
--- a/util.py
+++ b/util.py
@@ -1,10 +1,32 @@
+"""Utility helpers for file operations."""
+
+from __future__ import annotations
+
 import hashlib
 import os
+from typing import Optional
 
-def get_file_hash(filepath, block_size=65536):
-    """Calculates the SHA256 hash of a file to uniquely identify it.
-    Uses the first 10 blocks and last 10 blocks for a better representation
-    while maintaining performance."""
+def get_file_hash(filepath: str, block_size: int = 65536) -> Optional[str]:
+    """Return a stable hash for ``filepath``.
+
+    The function reads the first and last ten ``block_size`` byte chunks of the
+    file to construct a SHA256 hash.  Only a subset of the file is read so that
+    even very large media files can be fingerprinted quickly.  ``None`` is
+    returned if the file cannot be read.
+
+    Parameters
+    ----------
+    filepath:
+        Absolute path of the file to hash.
+    block_size:
+        Size of the chunks to read from the file in bytes.
+
+    Returns
+    -------
+    Optional[str]
+        The hexadecimal digest of the SHA256 hash or ``None`` if the file could
+        not be processed.
+    """
     sha256 = hashlib.sha256()
     try:
         file_size = os.path.getsize(filepath)


### PR DESCRIPTION
## Summary
- annotate util, scanner, and app modules with Python 3.10 type hints
- expand docstrings for clarity and maintainability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb24b78f883328cdf483acb8be00a