### PR TITLE
Add select all buttons in tag group

### DIFF
--- a/templates/group_tagger.html
+++ b/templates/group_tagger.html
@@ -16,6 +16,10 @@
                 <p>No faces found for this group. It may have been an error.</p>
             {% endfor %}
         </div>
+        <div class="text-center mb-4 space-x-2">
+            <button id="select-all" type="button" class="bg-gray-200 text-gray-800 font-semibold py-2 px-4 rounded-md hover:bg-gray-300">Select All Faces</button>
+            <button id="unselect-all" type="button" class="bg-gray-200 text-gray-800 font-semibold py-2 px-4 rounded-md hover:bg-gray-300">Unselect All Faces</button>
+        </div>
         <div class="text-center mb-6 space-x-2">
             <button type="submit" formaction="{{ url_for('split_cluster') }}" class="bg-yellow-500 text-white font-semibold py-2 px-4 rounded-md hover:bg-yellow-600">Split Selected Faces into New Group</button>
             <button type="submit" formaction="{{ url_for('remove_faces') }}" class="bg-red-500 text-white font-semibold py-2 px-4 rounded-md hover:bg-red-600">Remove Selected Faces</button>
@@ -104,6 +108,16 @@
         }
     }
     nameInput.addEventListener('input', checkDuplicate);
-    document.addEventListener('DOMContentLoaded', checkDuplicate);
+    document.addEventListener('DOMContentLoaded', () => {
+        checkDuplicate();
+        const selectAllBtn = document.getElementById('select-all');
+        const unselectAllBtn = document.getElementById('unselect-all');
+        selectAllBtn.addEventListener('click', () => {
+            document.querySelectorAll('.face-checkbox').forEach(cb => cb.checked = true);
+        });
+        unselectAllBtn.addEventListener('click', () => {
+            document.querySelectorAll('.face-checkbox').forEach(cb => cb.checked = false);
+        });
+    });
 </script>
 {% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -141,3 +141,21 @@ def test_tag_group_pagination(tmp_path, monkeypatch):
         assert resp2.status_code == 200
         assert b"Page 2 of 2" in resp2.data
 
+
+def test_tag_group_select_buttons(tmp_path, monkeypatch):
+    db_path = setup_app_db(tmp_path, monkeypatch)
+    conn = sqlite3.connect(db_path)
+    enc = pickle.dumps(np.array([0]))
+
+    conn.execute(
+        "INSERT INTO faces (file_hash, frame_number, face_location, face_encoding, cluster_id) VALUES (?, ?, ?, ?, ?)",
+        ("h1", 0, "0,0,0,0", enc, 1),
+    )
+    conn.commit()
+
+    with app_module.app.test_client() as client:
+        resp = client.get("/group/1")
+        assert resp.status_code == 200
+        assert b"Select All Faces" in resp.data
+        assert b"Unselect All Faces" in resp.data
+


### PR DESCRIPTION
## Summary
- add Select/Unselect All Faces controls on the group tagging page
- implement JS handlers for selecting and unselecting all checkboxes
- test presence of new buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ef1684e4883328a6720a1a6f6a15d