### PR TITLE
Add coverage for util hashing and signal handling

### DIFF
--- a/tests/test_signal_handler.py
+++ b/tests/test_signal_handler.py
@@ -1,0 +1,13 @@
+from signal_handler import SignalHandler
+
+
+def test_signal_handler_sets_flag_and_prints(capsys):
+    handler = SignalHandler()
+    assert handler.shutdown_requested is False
+
+    handler(15, None)
+    captured = capsys.readouterr()
+
+    assert "Shutdown signal 15 received" in captured.out
+    assert handler.shutdown_requested is True
+

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -20,3 +20,37 @@ def test_get_file_hash_changes(tmp_path):
 def test_get_file_hash_missing(tmp_path):
     missing = tmp_path / 'missing.txt'
     assert get_file_hash(str(missing)) is None
+
+
+def test_get_file_hash_large_file(tmp_path):
+    # Create a file larger than 10 blocks to exercise the tail-reading logic
+    big_file = tmp_path / 'big.bin'
+    big_file.write_bytes(b'a' * (65536 * 11))  # 11 blocks
+    hash_value = get_file_hash(str(big_file))
+    assert isinstance(hash_value, str) and len(hash_value) == 64
+
+
+def test_get_file_hash_generic_exception(tmp_path, monkeypatch):
+    # Create a real file so os.path.getsize succeeds
+    f = tmp_path / 'file.txt'
+    f.write_text('data')
+
+    def bad_open(*args, **kwargs):
+        raise ValueError('boom')
+
+    monkeypatch.setattr('builtins.open', bad_open)
+    assert get_file_hash(str(f)) is None
+
+
+def test_get_file_hash_tail_break(tmp_path, monkeypatch):
+    import os
+
+    # File with exactly 10 blocks
+    ten_block_file = tmp_path / 'ten.bin'
+    ten_block_file.write_bytes(b'a' * (65536 * 10))
+
+    # Pretend the file is larger so the tail-reading loop runs
+    monkeypatch.setattr(os.path, 'getsize', lambda _: 65536 * 11)
+
+    hash_value = get_file_hash(str(ten_block_file))
+    assert isinstance(hash_value, str) and len(hash_value) == 64


### PR DESCRIPTION
## Summary
- test util.get_file_hash with large files, broken reads and generic exceptions
- cover SignalHandler to ensure shutdown flag and message

## Testing
- `pytest --cov=. --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68a7d117cc488332b2e524020ee5f09b