### PR TITLE
Refactor prints to logging with central configuration

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,13 @@
 import os
+import logging
 from dataclasses import dataclass
 from typing import Optional
+
+# Configure application-wide logging format and level
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)s:%(name)s:%(message)s",
+)
 
 @dataclass
 class Config:

--- a/e2e_test.py
+++ b/e2e_test.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import sqlite3
 import tempfile
+import logging
 
 import ffmpeg
 
@@ -57,14 +58,15 @@ def run_pipeline(video_dir: str, work_dir: str) -> None:
         ).fetchone()[0]
         video_paths = [row[0] for row in conn.execute("SELECT last_known_filepath FROM scanned_files").fetchall()]
 
-    print(f"Faces: {face_count}")
-    print(f"Clusters: {cluster_count}")
+    logger = logging.getLogger(__name__)
+    logger.info("Faces: %s", face_count)
+    logger.info("Clusters: %s", cluster_count)
     for path in video_paths:
         try:
             comment = ffmpeg.probe(path).get("format", {}).get("tags", {}).get("comment", "")
         except Exception:
             comment = ""
-        print(f"{os.path.basename(path)} comment: {comment}")
+        logger.info("%s comment: %s", os.path.basename(path), comment)
 
 
 def main() -> None:

--- a/signal_handler.py
+++ b/signal_handler.py
@@ -1,3 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class SignalHandler:
     """A class to handle shutdown signals gracefully."""
@@ -6,5 +10,8 @@ class SignalHandler:
         self.shutdown_requested = False
 
     def __call__(self, signum, frame):
-        print(f"\n[Main] Shutdown signal {signum} received. Finishing current tasks and saving...")
+        logger.info(
+            "[Main] Shutdown signal %s received. Finishing current tasks and saving...",
+            signum,
+        )
         self.shutdown_requested = True

--- a/tests/test_signal_handler.py
+++ b/tests/test_signal_handler.py
@@ -1,13 +1,15 @@
+import logging
+
 from signal_handler import SignalHandler
 
 
-def test_signal_handler_sets_flag_and_prints(capsys):
+def test_signal_handler_sets_flag_and_logs(caplog):
     handler = SignalHandler()
     assert handler.shutdown_requested is False
 
-    handler(15, None)
-    captured = capsys.readouterr()
+    with caplog.at_level(logging.INFO):
+        handler(15, None)
 
-    assert "Shutdown signal 15 received" in captured.out
+    assert "Shutdown signal 15 received" in caplog.text
     assert handler.shutdown_requested is True
 

--- a/util.py
+++ b/util.py
@@ -1,5 +1,8 @@
 import hashlib
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 def get_file_hash(filepath, block_size=65536):
     """Calculates the SHA256 hash of a file to uniquely identify it.
@@ -31,8 +34,8 @@ def get_file_hash(filepath, block_size=65536):
 
         return sha256.hexdigest()
     except IOError:
-        print(f"  - [Hash Error] Could not read file: {filepath}")
+        logger.warning("  - [Hash Error] Could not read file: %s", filepath)
         return None
     except Exception as e:
-        print(f"  - [Hash Error] Error processing file {filepath}: {str(e)}")
+        logger.warning("  - [Hash Error] Error processing file %s: %s", filepath, str(e))
         return None


### PR DESCRIPTION
## Summary
- Configure application-wide logging defaults
- Replace print statements with logging across core modules
- Update tests to capture log output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7d3dc8a788332948131b60d8134c5